### PR TITLE
`chore`: release `v1.0.4` - critical `bug` fixes and `dependency` updates

### DIFF
--- a/git-time-travel-cli.js
+++ b/git-time-travel-cli.js
@@ -182,7 +182,7 @@ exec(`git log -n1 --pretty=format:"${datefmt}"`, (error, stdout) => {
             )
           );
           rl.close();
-          process.exit(1);
+          process.exit(0);
         }
       );
     });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "git-time-travel",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Git Time Travel is a powerful Node.js package that lets you manipulate the date and time of any previous Git commit in your repository. With Git Time Travel, you can easily correct mistakes or update information in your Git history without having to rewrite your entire commit history.Try Git Time Travel today and take control of your Git history!",
   "main": "git-time-travel-cli.js",
   "type": "module",
@@ -29,18 +29,18 @@
   "author": "Souvik Sen",
   "license": "MIT",
   "dependencies": {
-    "chalk": "^5.2.0",
-    "figlet": "^1.5.2",
-    "ora": "^6.1.2",
+    "chalk": "^5.6.2",
+    "figlet": "^1.9.3",
+    "ora": "^6.3.1",
     "readline": "^1.3.0",
     "tempfile": "^4.0.0"
   },
   "devDependencies": {
-    "@babel/core": "^7.20.12",
-    "@babel/register": "^7.18.9",
-    "chai": "^4.3.7",
-    "chai-as-promised": "^7.1.1",
-    "mocha": "^10.2.0"
+    "@babel/core": "^7.28.5",
+    "@babel/register": "^7.28.3",
+    "chai": "^4.5.0",
+    "chai-as-promised": "^7.1.2",
+    "mocha": "^10.8.2"
   },
   "bugs": {
     "url": "https://github.com/Yourstruggle11/git-time-travel/issues"

--- a/test/cmd.js
+++ b/test/cmd.js
@@ -59,7 +59,7 @@ describe("Git time traveler", () => {
 
   it("should execute the specified editor with the temporary file", () => {
     // Replace "vim" with the path to your preferred editor.
-    const editor = "CODE";
+    const editor = "code";
     const cmd = `${editor} tempfile`;
     return new Promise((resolve, reject) => {
       exec(cmd, (error) => {
@@ -100,7 +100,7 @@ describe("Git time traveler", () => {
     // Create a Git repository and add a commit to it.
     return expect(
       new Promise((resolve, reject) => {
-        const tmpdir = fs.mkdtempSync("/tmp");
+        const tmpdir = fs.mkdtempSync(path.join(process.cwd(), "temp-"));
         const repoPath = path.join(tmpdir, "repo");
         fs.mkdirSync(repoPath);
         process.chdir(repoPath);

--- a/utils/rewriteGitHistory.js
+++ b/utils/rewriteGitHistory.js
@@ -13,16 +13,16 @@ export const rewriteGitHistory =  (file, index, collectionLength,spinner) => {
         );
         fs.unlink(`${file}`, (err) => {
           if (err) {
-            spinner.fail(`Error: ${error}`);
+            spinner.fail(`Error: ${err}`);
             process.exit(1);
           }
         });
       } catch (error) {
         spinner.fail(`Error: ${error}`);
-        // Delete the .sh file if there is any erroe
+        // Delete the .sh file if there is any error
         fs.unlink(`${file}`, (err) => {
           if (err) {
-            spinner.fail(`Error: ${error}`);
+            spinner.fail(`Error: ${err}`);
             process.exit(1);
           }
         });

--- a/utils/showHelp.js
+++ b/utils/showHelp.js
@@ -2,7 +2,7 @@ export const showHelp = () => {
     console.log("Usage: git-time-travel [options]");
     console.log("");
     console.log("Options:");
-    console.log("  -c, --commits [number]  Numer of commits to modify. If not specified, the last 5 commits will be used.");
+    console.log("  -c, --commits [number]  Number of commits to modify. If not specified, the last 5 commits will be used.");
     console.log("  -l, --limit [number]    specifies the number of chunks to split each commit into, with the default value being 20");
     console.log("  -d, --debug             specifies whether to enable debug mode or not");
     console.log("  -a or --all             specifies whether to change date for all available commits.");


### PR DESCRIPTION
Fixes:
- Fix incorrect exit code (exit 0 on success instead of 1)
- Fix error variable reference mismatches in rewriteGitHistory.js
- Fix typo in help text ('Numer' -> 'Number')
- Fix test compatibility for Windows (temp path and editor name)

Updates:
- Update all dependencies to latest compatible versions
  - chalk: 5.2.0 -> 5.6.2
  - figlet: 1.5.2 -> 1.9.3
  - ora: 6.1.2 -> 6.3.1
  - @babel/core: 7.20.12 -> 7.28.5
  - @babel/register: 7.18.9 -> 7.28.3
  - chai: 4.3.7 -> 4.5.0
  - chai-as-promised: 7.1.1 -> 7.1.2
  - mocha: 10.2.0 -> 10.8.2